### PR TITLE
Fix ID rebuild off-by-one bug and GLSL compilation errors

### DIFF
--- a/rust-utils/src/commands/rebuild_ids.rs
+++ b/rust-utils/src/commands/rebuild_ids.rs
@@ -402,11 +402,11 @@ pub fn function(args: &[String]) -> Result<()> {
 		}
 		if let Some(leaf) = &mut node.leaf {
 			leaf.voxel_id = *curr_voxel_id;
-			*curr_voxel_id += 1;
 			unsafe {
 				// Safety: idk as long as the output is good I'm happy
 				*leaf.block_data.voxel_id.get() = *curr_voxel_id;
 			}
+			*curr_voxel_id += 1;
 		}
 	}
 	let mut curr_voxel_id = 2;

--- a/shaders/basics/settings.glsl
+++ b/shaders/basics/settings.glsl
@@ -169,7 +169,7 @@ const float shadowIntervalSize    = 2.0;
 	#undef BLOOM_NETHER_AMOUNT
 	#undef BLOOM_END_AMOUNT
 	#undef VIBRANCE
-	#undef SATURATION 0.1
+	#undef SATURATION
 	#define BLOOM_STYLE 2
 	#define BLOOM_SIZE 2.0
 	#define BLOOM_AMOUNT 2.2

--- a/shaders/basics/uniforms.glsl
+++ b/shaders/basics/uniforms.glsl
@@ -183,7 +183,7 @@ const float ambientSunsetStart = 0.4;
 const float ambientSunsetEnd = 0.56;
 
 float ambientSunPercent = sunAngle >= 0.0 && sunAngle < ambientSunriseEnd ? (sunAngle - 0.0) / (ambientSunriseEnd - 0.0) : sunAngle >= ambientSunriseEnd && sunAngle < ambientSunsetStart ? 1.0 : sunAngle >= ambientSunsetStart && sunAngle < 0.5 ? 1.0 - (sunAngle - ambientSunsetStart) / (0.5 - ambientSunsetStart) : 0.0;
-float rawAmbientMoonPercent = sunAngle >= 0.5 && sunAngle < ambientSunsetEnd ? pow((sunAngle - 0.5) / (ambientSunsetEnd - 0.5), 2) : sunAngle >= ambientSunsetEnd && sunAngle < ambientSunriseStart ? 1.0 : sunAngle >= ambientSunriseStart && sunAngle < 1.0 ? pow(1.0 - (sunAngle - ambientSunriseStart) / (1.0 - ambientSunriseStart), 2) : 0.0;
+float rawAmbientMoonPercent = sunAngle >= 0.5 && sunAngle < ambientSunsetEnd ? pow((sunAngle - 0.5) / (ambientSunsetEnd - 0.5), 2.0) : sunAngle >= ambientSunsetEnd && sunAngle < ambientSunriseStart ? 1.0 : sunAngle >= ambientSunriseStart && sunAngle < 1.0 ? pow(1.0 - (sunAngle - ambientSunriseStart) / (1.0 - ambientSunriseStart), 2.0) : 0.0;
 float ambientMoonPercent = 1.0 - (1.0 - rawAmbientMoonPercent) * (1.0 - rawAmbientMoonPercent) * (1.0 - rawAmbientMoonPercent);
 float ambientSunrisePercent = sunAngle >= ambientSunriseStart && sunAngle < 1.0 ? 1.0 - ambientMoonPercent : sunAngle >= 0.0 && sunAngle < ambientSunriseEnd ? 1.0 - ambientSunPercent : 0.0;
 float ambientSunsetPercent = sunAngle >= ambientSunsetStart && sunAngle < 0.5 ? 1.0 - ambientSunPercent : sunAngle >= 0.5 && sunAngle < ambientSunsetEnd ? 1.0 - ambientMoonPercent : 0.0;

--- a/shaders/program/gbuffers_terrain.glsl
+++ b/shaders/program/gbuffers_terrain.glsl
@@ -170,7 +170,6 @@ void main() {
 	#endif
 	
 	#if EMISSIVE_TEXTURES_ENABLED == 1
-		float specularness = specularness;
 		vec3 hsv = rgbToHsv(rawColor.rgb);
 		if (all(greaterThan(hsv, glowingColorMin)) && all(lessThan(hsv, glowingColorMax))) {
 			glowing = 1.0;


### PR DESCRIPTION
- Corrected voxel ID assignment timing in `rebuild_ids` command so generated GLSL files match voxel properties accurately.
- Removed invalid trailing token in `#undef SATURATION` directive in `settings.glsl`.
- Updated `pow()` calls in `uniforms.glsl` to use float literals for exponent parameters.
- Removed invalid variable redefinition of `specularness` in `gbuffers_terrain.glsl`.